### PR TITLE
convert Rfc3986Escape from O(m*n) to O(n)

### DIFF
--- a/oauth1a_test.go
+++ b/oauth1a_test.go
@@ -189,8 +189,8 @@ func TestTimestampOverride(t *testing.T) {
 }
 
 var ESCAPE_TESTS = map[string]string{
-	"Ā": "%C4%80",
-	"㤹": "%E3%A4%B9",
+	"Ā":  "%C4%80",
+	"㤹":  "%E3%A4%B9",
 	"\n": "%0A",
 	"\r": "%0D",
 }


### PR DESCRIPTION
No need to walk through all of the UNESCAPE_CHARS string when we can do simple byte comparisons.