### PR TITLE
make Rfc3986Escape a NOP in the common case

### DIFF
--- a/oauth1a_test.go
+++ b/oauth1a_test.go
@@ -189,16 +189,22 @@ func TestTimestampOverride(t *testing.T) {
 }
 
 var ESCAPE_TESTS = map[string]string{
-	"Ā":  "%C4%80",
-	"㤹":  "%E3%A4%B9",
-	"\n": "%0A",
-	"\r": "%0D",
+	"aaaa":   "aaaa",
+	"Ā":      "%C4%80",
+	"Ā㤹":     "%C4%80%E3%A4%B9",
+	"bbĀ㤹":   "bb%C4%80%E3%A4%B9",
+	"Ā㤹bb":   "%C4%80%E3%A4%B9bb",
+	"bbĀ㤹bb": "bb%C4%80%E3%A4%B9bb",
+	"㤹":      "%E3%A4%B9",
+	"\n":     "%0A",
+	"\r":     "%0D",
 }
 
 func TestEscaping(t *testing.T) {
 	for str, expected := range ESCAPE_TESTS {
-		if Rfc3986Escape(str) != expected {
-			t.Errorf("Escaped %v was %v, expected %v", str, Rfc3986Escape(str), expected)
+		actual := Rfc3986Escape(str)
+		if actual != expected {
+			t.Errorf("Escaped %v was %v, expected %v", str, actual, expected)
 		}
 	}
 }


### PR DESCRIPTION
Rfc3986Escape now returns the input string immediately if nothing inside it needs to be escaped.

This avoids doing the annoying allocations for the output buffer and its bytes as well as the string copy at the end.

It also tracks the prefix of okay input bytes, adds them to the output buffer, and avoids repeating the work of checking them again.

This builds on the work in #7 and it should go in first.